### PR TITLE
Issue #3 - Unexpected end of JSON input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
-### [1.0.2] 2021-01-12
+### [1.0.2] -  2021-01-13
+
+#### Added
+- Changelog diff links
+- Changelog links to Klaviyo API documentation where appropriate
 
 #### Fixed
 - Delete methods now return an empty object on success, rather than raising an "Unexpected end of JSON input" error.
 
-### [1.0.1] 2020-12-07
+### [1.0.1] -  2020-12-07
 
 #### Added
 - Created CHANGELOG.md
 
-### [1.0.0] 2020-12-07
+### [1.0.0] - 2020-12-07
 
 #### Added
-- Support for Public API endpoints (track and identify)
-- Support for Profiles API
-- Support for Metrics API
-- Support for v2 List API
+- Support for [Public API](https://www.klaviyo.com/docs/http-api) endpoints (track and identify)
+- Support for [Profiles API](https://www.klaviyo.com/docs/api/people)
+- Support for [Metrics API](https://www.klaviyo.com/docs/api/metrics)
+- Support for [V2 List API](https://www.klaviyo.com/docs/api/v2/lists)
+
+[Unreleased]: https://github.com/klaviyo/node-klaviyo/compare/1.0.2...HEAD
+[1.0.2]: https://github.com/klaviyo/node-klaviyo/compare/26cf1da1612e3a2aea924210e2a48486345f474b...1.0.2
+[1.0.1]: https://github.com/klaviyo/node-klaviyo/compare/c63216437dc38e98ffd86c88df3c6f6a63381934...26cf1da1612e3a2aea924210e2a48486345f474b
+[1.0.0]: https://github.com/klaviyo/node-klaviyo/compare/6db9369980447ef4cfccfa018d5ebaaa27ef0f04...c63216437dc38e98ffd86c88df3c6f6a63381934

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
+### [1.0.2] 2021-01-12
+
+#### Fixed
+- Delete methods now return an empty object on success, rather than raising an "Unexpected end of JSON input" error.
+
 ### [1.0.1] 2020-12-07
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### [Unreleased]
 
-### [1.0.2] -  2021-01-13
+### [1.0.2] - 2021-01-13
 
 #### Added
 - Changelog diff links
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Fixed
 - Delete methods now return an empty object on success, rather than raising an "Unexpected end of JSON input" error.
 
-### [1.0.1] -  2020-12-07
+### [1.0.1] - 2020-12-07
 
 #### Added
 - Created CHANGELOG.md

--- a/lib/request.js
+++ b/lib/request.js
@@ -89,7 +89,7 @@ class Request {
 
 function processBuffer(data = []) {
     if (!data[0]) {
-        data = '';
+        data = '{}';
     } else {
         data = Buffer.concat(data);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-klaviyo",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Klaviyo API wrapper",
   "main": "./lib/klaviyo.js",
   "scripts": {


### PR DESCRIPTION
JSON.parse() throws an error if we just give an empty string. This change updates the response parsing to use an empty object if the API returns an empty body (which occurs on some delete methods).